### PR TITLE
cAdvisorClient for collecting container network details.

### DIFF
--- a/vendor/github.com/Huawei-PaaS/CNI-Genie/genie/genie-monitor.go
+++ b/vendor/github.com/Huawei-PaaS/CNI-Genie/genie/genie-monitor.go
@@ -10,7 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package main
+package genie
 
 import (
 	//"fmt"

--- a/vendor/github.com/Huawei-PaaS/CNI-Genie/utils/sort-map-values.go
+++ b/vendor/github.com/Huawei-PaaS/CNI-Genie/utils/sort-map-values.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"sort"
+)
+
+// sort a map's keys in ascending order of its values.
+
+type sortedMap struct {
+	m map[string]int
+	s []string
+}
+
+func (sm *sortedMap) Len() int {
+	return len(sm.m)
+}
+
+func (sm *sortedMap) Less(i, j int) bool {
+	return sm.m[sm.s[i]] < sm.m[sm.s[j]]
+}
+
+func (sm *sortedMap) Swap(i, j int) {
+	sm.s[i], sm.s[j] = sm.s[j], sm.s[i]
+}
+
+func SortedKeys(m map[string]int) []string {
+	sm := new(sortedMap)
+	sm.m = m
+	sm.s = make([]string, len(m))
+	i := 0
+	for key, _ := range m {
+		sm.s[i] = key
+		i++
+	}
+	sort.Sort(sm)
+	return sm.s
+}
+

--- a/vendor/github.com/Huawei-PaaS/CNI-Genie/utils/types.go
+++ b/vendor/github.com/Huawei-PaaS/CNI-Genie/utils/types.go
@@ -2,9 +2,32 @@ package utils
 
 import (
 	"net"
+	c "github.com/google/cadvisor/info/v1"
 	"github.com/containernetworking/cni/pkg/types"
 	v1 "github.com/projectcalico/cni-plugin/utils"
+	"time"
 )
+
+type ContainerInfoGenie struct {
+	// Historical statistics gathered from the container.
+	Stats []ContainerStatsGenie `json:"stats,omitempty"`
+}
+
+type ContainerStatsGenie struct {
+	// The time of this stat point.
+	Timestamp time.Time    `json:"timestamp"`
+	Network   c.NetworkStats `json:"network,omitempty"`
+}
+
+type InterfaceBandwidthUsage struct {
+	IntName string
+	UpLink uint64
+	DownLink uint64
+}
+
+type AllInterfaces struct {
+	Interfaces []c.InterfaceStats
+}
 
 // NetConf stores the common network config for Calico CNI plugin
 type NetConf struct {


### PR DESCRIPTION
Following changes done:
* genie-cadvisor-client.go --> collects network usage of all interfaces
* sort-map-values --> sorts values of map by asc order and return key as string array

* types.go --> added new types to track downlink and uplink speeds of interface
We only collect the downlink and uplink of interfaces we are interested in.