### PR TITLE
cni-genie integration with genie-cadvisor-client

### DIFF
--- a/vendor/github.com/Huawei-PaaS/CNI-Genie/genie/genie-cadvisor-client.go
+++ b/vendor/github.com/Huawei-PaaS/CNI-Genie/genie/genie-cadvisor-client.go
@@ -202,7 +202,18 @@ func computeNetworkUsage(cinfo []ContainerStatsGenie) ([]string) {
 	glog.V(6).Info("m==>", m)
 	//sort by values of map
 	cns := SortedKeys(m)
+	for i, c := range cns {
+		if c == "weav" {
+			cns[i] = "weave"
+		} else if c == "flan" {
+			cns[i] = "canal"
+		} else if c == "cali" {
+			cns[i] = "calico"
+		}
+	}
 	fmt.Println("cns==>", cns)
+
+
 	//fmt.Println("cns==>", cns)
 	return cns
 }


### PR DESCRIPTION
Following is what this code does:
* Checks annotation of pod definition if empty network name.
  If so then genie calls genie-cadvisor-client to get list of
  network names in ascending order of downlink values.
* genie picks first networn name in the list
* genie updates the pod definition with network name

Module affected: CNI-Genie core