### PR TITLE
Fixing Unit Tests to support K8S v1.6+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ dist/genie: $(SRCFILES)
 
 # Build the genie cni plugin tests
 dist/genie-test: $(TEST_SRCFILES)
-	@GOPATH=$(GO_PATH) CGO_ENABLED=0 ETCD_IP=127.0.0.1 PLUGIN=genie CNI_SPEC_VERSION=0.3.0 go test
+	@GOPATH=$(GO_PATH) CGO_ENABLED=0 ETCD_IP=127.0.0.1 PLUGIN=genie CNI_SPEC_VERSION=0.3.0 go test -args --testKubeVersion=$(testKubeVersion) --testKubeConfig=$(testKubeConfig)


### PR DESCRIPTION
changes made:
* Added common logic for Namespace creation into
  BeforeSuite
* Added namespace deletion to AfterSuite
* Added support for flags - testKubeVersion & testKubeConfig
* End user may now pass these flags as a part of testing
  CNI-Genie against specific kube version & location of
  kubeconfig file