### PR TITLE
Add the ability to explicitly supply a default CNI plugin to run when no annotation is found.

### DIFF
--- a/utils/types.go
+++ b/utils/types.go
@@ -16,11 +16,12 @@
 package utils
 
 import (
+	"net"
+	"time"
+
 	"github.com/containernetworking/cni/pkg/types"
 	c "github.com/google/cadvisor/info/v1"
 	v1 "github.com/projectcalico/cni-plugin/utils"
-	"net"
-	"time"
 )
 
 type ContainerInfoGenie struct {
@@ -68,6 +69,7 @@ type NetConf struct {
 		IPv4Pools  []string `json:"ipv4_pools,omitempty"`
 		IPv6Pools  []string `json:"ipv6_pools,omitempty"`
 	} `json:"ipam,omitempty"`
+	Default        string        `json:"default"`
 	MTU            int           `json:"mtu"`
 	Hostname       string        `json:"hostname"`
 	DatastoreType  string        `json:"datastore_type"`


### PR DESCRIPTION
This PR is based off https://github.com/Huawei-PaaS/CNI-Genie/pull/30.
In addition to adding a default in the genie netconf file. It fixes an
issue with this base PR where it would Unmarshall another CNI plugin
into a Genie specific NetConf struct then Marshal it back out to JSON.
This caused the delegate plugin to fail usually because it was being
passed JSON fields that were empty. The solution was to pass the
delegate CNI plugin's netconf config into the ipam call, without the
marshall/unmarshall steps.