### PR TITLE
Kubernetes RBAC support

### DIFF
--- a/conf/genie-rbac.yaml
+++ b/conf/genie-rbac.yaml
@@ -1,0 +1,146 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: genie
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: genie
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: genie
+subjects:
+- kind: ServiceAccount
+  name: genie
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: genie
+  namespace: kube-system
+
+---
+# This ConfigMap can be used to configure a self-hosted CNI-Genie installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: genie-config
+  namespace: kube-system
+data:
+  # The CNI network configuration to install on each node.
+  cni_genie_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "genie",
+        "log_level": "info",
+        "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "/etc/cni/net.d/genie-kubeconfig"
+        },
+        "romana_root": "http://__ROMANA_SERVICE_HOST__:__ROMANA_SERVICE_PORT__",
+        "segment_label_name": "romanaSegment"
+    }
+
+---
+# Install CNI-Genie plugin on each slave node.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: genie
+  namespace: kube-system
+  labels:
+    k8s-app: genie
+spec:
+  selector:
+    matchLabels:
+      k8s-app: genie
+  template:
+    metadata:
+      labels:
+        k8s-app: genie
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [
+            {
+              "key": "dedicated",
+              "value": "master",
+              "effect": "NoSchedule"
+            },
+            {
+              "key": "CriticalAddonsOnly",
+              "operator": "Exists"
+            }
+          ]
+    spec:
+      hostNetwork: true
+      hostPID: true
+      serviceAccountName: genie
+      containers:
+        # Create a container with install.sh that
+        # Installs required 00-genie.conf and genie binary
+        # on slave node.
+        - name: install-cni
+          image: quay.io/cnigenie/v1.5:latest
+          command: ["/launch.sh"]
+          env:
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: genie-config
+                  key: cni_genie_network_config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by genie/node.
+        #- name: lib-modules
+        #  hostPath:
+        #    path: /lib/modules
+        #- name: var-run-genie
+        #  hostPath:
+        #    path: /var/run/genie
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d


### PR DESCRIPTION
Since Kubernetes 1.6 RBAC policies are enabled by default. Add
ClusterRole with required privileages to mitigate errors like this:

    ParsePodAnnotations: the server does not allow access to the
    requested resource (get pods multi)