### PR TITLE
Modification for delegate structure

### DIFF
--- a/utils/types.go
+++ b/utils/types.go
@@ -68,23 +68,23 @@ type NetConf struct {
 		IPv4Pools  []string `json:"ipv4_pools,omitempty"`
 		IPv6Pools  []string `json:"ipv6_pools,omitempty"`
 	} `json:"ipam,omitempty"`
-	MTU            int           `json:"mtu"`
-	Hostname       string        `json:"hostname"`
-	DatastoreType  string        `json:"datastore_type"`
-	EtcdAuthority  string        `json:"etcd_authority"`
-	EtcdEndpoints  string        `json:"etcd_endpoints"`
-	LogLevel       string        `json:"log_level"`
-	Policy         v1.Policy     `json:"policy"`
-	Kubernetes     v1.Kubernetes `json:"kubernetes"`
-	Args           v1.Args       `json:"args"`
-	EtcdScheme     string        `json:"etcd_scheme"`
-	EtcdKeyFile    string        `json:"etcd_key_file"`
-	EtcdCertFile   string        `json:"etcd_cert_file"`
-	EtcdCaCertFile string        `json:"etcd_ca_cert_file"`
-	Delegate       v1.Delegate   `json:"delegate"`
-	CalicoSubnet   string        `json:"calico_subnet"`
-	CanalSubnet    string        `json:"canal_subnet"`
-	WeaveSubnet    string        `json:"weave_subnet"`
+	MTU            int                    `json:"mtu"`
+	Hostname       string                 `json:"hostname"`
+	DatastoreType  string                 `json:"datastore_type"`
+	EtcdAuthority  string                 `json:"etcd_authority"`
+	EtcdEndpoints  string                 `json:"etcd_endpoints"`
+	LogLevel       string                 `json:"log_level"`
+	Policy         v1.Policy              `json:"policy"`
+	Kubernetes     v1.Kubernetes          `json:"kubernetes"`
+	Args           v1.Args                `json:"args"`
+	EtcdScheme     string                 `json:"etcd_scheme"`
+	EtcdKeyFile    string                 `json:"etcd_key_file"`
+	EtcdCertFile   string                 `json:"etcd_cert_file"`
+	EtcdCaCertFile string                 `json:"etcd_ca_cert_file"`
+	Delegate       map[string]interface{} `json:"delegate"`
+	CalicoSubnet   string                 `json:"calico_subnet"`
+	CanalSubnet    string                 `json:"canal_subnet"`
+	WeaveSubnet    string                 `json:"weave_subnet"`
 
 	//added for romana
 	RomanaRoot       string `json:"romana_root"`


### PR DESCRIPTION



Modification summary: Current delegate structure used by genie is specific to calico. This modification is for making it as generic so that other plugin delegates can also be handled

This modification will resolve below 2 issues
https://github.com/Huawei-PaaS/CNI-Genie/issues/52
https://github.com/Huawei-PaaS/CNI-Genie/issues/47


Detailed Test Report Attached:

[Test-report .docx](https://github.com/Huawei-PaaS/CNI-Genie/files/1458153/Test-report.docx)
