### PR TITLE
Cluster role support

### DIFF
--- a/conf/1.8/Dockerfile
+++ b/conf/1.8/Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox
+
+ADD dist/genie /opt/cni/bin/genie
+ADD conf/1.8/launch.sh /launch.sh
+RUN chmod +x /launch.sh
+
+ENV PATH=$PATH:/opt/cni/bin
+VOLUME /opt/cni
+WORKDIR /opt/cni/bin

--- a/conf/1.8/genie.yaml
+++ b/conf/1.8/genie.yaml
@@ -1,0 +1,133 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: genie
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: genie
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: genie
+subjects:
+- kind: ServiceAccount
+  name: genie
+  namespace: kube-system
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: genie
+  namespace: kube-system
+---
+# This ConfigMap can be used to configure a self-hosted CNI-Genie installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: genie-config
+  namespace: kube-system
+data:
+  # The CNI network configuration to install on each node.
+  cni_genie_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "genie",
+        "log_level": "info",
+        "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "/etc/cni/net.d/genie-kubeconfig"
+        },
+        "romana_root": "http://__ROMANA_SERVICE_HOST__:__ROMANA_SERVICE_PORT__",
+        "segment_label_name": "romanaSegment"
+    }
+
+---
+# Install CNI-Genie plugin on each slave node.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: genie
+  namespace: kube-system
+  labels:
+    k8s-app: genie
+spec:
+  selector:
+    matchLabels:
+      k8s-app: genie
+  template:
+    metadata:
+      labels:
+        k8s-app: genie
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [
+            {
+              "key": "dedicated", 
+              "value": "master", 
+              "effect": "NoSchedule" 
+            },
+            {
+              "key": "CriticalAddonsOnly", 
+              "operator": "Exists"
+            }
+          ]
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+        # Create a container with install.sh that 
+        # Installs required 00-genie.conf and genie binary
+        # on slave node.
+        - name: install-cni
+          image: quay.io/cnigenie/v1.5:latest
+          command: ["/launch.sh"]
+          env:
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: genie-config
+                  key: cni_genie_network_config
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by genie/node.
+        #- name: lib-modules
+        #  hostPath:
+        #    path: /lib/modules
+        #- name: var-run-genie
+        #  hostPath:
+        #    path: /var/run/genie
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d

--- a/conf/1.8/launch.sh
+++ b/conf/1.8/launch.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+
+# Make sure to have mounted /host/opt/cni/bin /host/etc/cni/net.d
+# Make sure CNI_GENIE_NETWORK_CONFIG config map env is set.
+
+# Ensure all variables are defined.
+set -u
+
+# Default CNI networks directory and security certificates location
+HOST_CNI_NET_DIR=${CNI_NET_DIR:-/etc/cni/net.d}
+HOST_SECRETS_DIR=${HOST_CNI_NET_DIR}/genie-tls
+
+# Directory where we expect that TLS assets will be mounted into
+# the genie/cni container.
+SECRETS_MOUNT_DIR=${TLS_ASSETS_DIR:-/genie-secrets}
+
+# Clean up any existing binaries / config / assets.
+rm -f /host/opt/cni/bin/genie
+rm -f /host/etc/cni/net.d/genie-tls/*
+
+# Copy over any TLS assets from the SECRETS_MOUNT_DIR to the host.
+if [ -e "${SECRETS_MOUNT_DIR}" ];
+then
+        echo "Installing any TLS assets from ${SECRETS_MOUNT_DIR}"
+        mkdir -p /host/etc/cni/net.d/genie-tls
+        cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/genie-tls/
+fi
+
+# If the TLS assets actually exist, update the variables to populate into the
+# CNI network config.  Otherwise, we'll just fill that in with blanks.
+if [ -e "/host/etc/cni/net.d/genie-tls/etcd-ca" ];
+then
+        CNI_CONF_ETCD_CA=${HOST_SECRETS_DIR}/etcd-ca
+fi
+
+if [ -e "/host/etc/cni/net.d/genie-tls/etcd-key" ];
+then
+        CNI_CONF_ETCD_KEY=${HOST_SECRETS_DIR}/etcd-key
+fi
+
+if [ -e "/host/etc/cni/net.d/genie-tls/etcd-cert" ];
+then
+        CNI_CONF_ETCD_CERT=${HOST_SECRETS_DIR}/etcd-cert
+fi
+
+# Place the new binaries if the directory is writeable.
+if [ -w "/host/opt/cni/bin/" ]; then
+        cp /opt/cni/bin/genie /host/opt/cni/bin/
+        echo "Wrote CNIGenie CNI binaries to /host/opt/cni/bin/"
+        echo "CNI plugin version: $(/host/opt/cni/bin/genie -v)"
+fi
+
+TMP_CONF='/genie.conf.tmp'
+# If specified, overwrite the network configuration file.
+if [ "${CNI_NETWORK_CONFIG:-}" != "" ]; then
+cat >$TMP_CONF <<EOF
+${CNI_NETWORK_CONFIG:-}
+EOF
+fi
+
+# Write a kubeconfig file for the CNI plugin. 
+# For now it doesn't use TLS, will be added in future.
+cat > /host/etc/cni/net.d/genie-kubeconfig <<EOF
+# Kubeconfig file for CNIGenie CNI plugin.
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    insecure-skip-tls-verify: true
+users:
+- name: genie
+contexts:
+- name: genie-context
+  context:
+    cluster: local
+    user: genie
+current-context: genie-context
+EOF
+
+SERVICEACCOUNT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+sed -i s/__KUBERNETES_SERVICE_HOST__/${KUBERNETES_SERVICE_HOST:-}/g $TMP_CONF
+sed -i s/__KUBERNETES_SERVICE_PORT__/${KUBERNETES_SERVICE_PORT:-}/g $TMP_CONF
+sed -i s/__KUBERNETES_NODE_NAME__/${KUBERNETES_NODE_NAME:-$(hostname)}/g $TMP_CONF
+sed -i s/__SERVICEACCOUNT_TOKEN__/${SERVICEACCOUNT_TOKEN:-}/g $TMP_CONF
+
+#For supporting Romana
+sed -i s/__ROMANA_SERVICE_HOST__/${ROMANA_ROOT_SERVICE_HOST:-}/g $TMP_CONF
+sed -i s/__ROMANA_SERVICE_PORT__/${ROMANA_ROOT_SERVICE_PORT:-}/g $TMP_CONF
+
+#contains path hence using * instead of /
+# NOTWORKING!
+#sed -i s*__KUBECONFIG_FILEPATH__*/etc/cni/net.d/genie-kubeconfig*g $TMP_CONF
+
+# Move the temporary CNI config into place.
+FILENAME=${CNI_CONF_NAME:-00-genie.conf}
+mv $TMP_CONF /host/etc/cni/net.d/${FILENAME}
+echo "Wrote CNI config: $(cat /host/etc/cni/net.d/${FILENAME})"
+
+# Unless told otherwise, sleep forever.
+# This prevents Kubernetes from restarting the pod repeatedly.
+should_sleep=${SLEEP:-"true"}
+echo "Done configuring CNI.  Sleep=$should_sleep"
+while [ "$should_sleep" == "true"  ]; do
+        # Kubernetes Secrets can be updated.  If so, we need to install the updated
+        # version to the host. Just check the timestamp on the certificate to see if it
+        # has been updated.  A bit hokey, but likely good enough.
+        stat_output=$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)
+        sleep 10;
+        if [ "$stat_output" != "$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)" ]; then
+                echo "Updating installed secrets at: $(date)"
+                cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/genie-tls/
+        fi
+done
+

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -8,6 +8,7 @@
 * Kubernetes cluster running with CNI enabled
   * One easy way to bring up a cluster is to use [kubeadm](https://kubernetes.io/docs/getting-started-guides/kubeadm/): 
       * We tested on Kubernetes 1.5, 1.6, 1.7, 1.8
+      
       Till 1.7 version:
       ```
       $ kubeadm init --use-kubernetes-version=v1.7.0 --pod-network-cidr=10.244.0.0/16
@@ -36,6 +37,7 @@
 ### Installing genie
 
 We install genie as a Docker Container on every node
+
 Till Kubernetes 1.7 version: 
 ```
 $ kubectl apply -f https://raw.githubusercontent.com/Huawei-PaaS/CNI-Genie/master/conf/1.5/genie.yaml
@@ -86,7 +88,7 @@ $ tail -f /var/log/syslog | grep 'CNI'
 
 * Note: one a single node cluster, after your Kubernetes master is initialized successfully, make sure you are able to schedule pods on the master by running:
 ```
-$ kubectl taint nodes --all dedicated-
+$ kubectl taint nodes --all node-role.kubernetes.io/master-
 ```
-* Note: most plugins use differenet installation files for Kuberenetes 1.5, 1.6 & 1.7. Make sure you use the right one!
+* Note: most plugins use differenet installation files for Kuberenetes 1.5, 1.6, 1.7 & 1.8. Make sure you use the right one!
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -7,9 +7,19 @@
 * Docker installed
 * Kubernetes cluster running with CNI enabled
   * One easy way to bring up a cluster is to use [kubeadm](https://kubernetes.io/docs/getting-started-guides/kubeadm/): 
-      * We tested on Kubernetes 1.5, 1.6, 1.7
+      * We tested on Kubernetes 1.5, 1.6, 1.7, 1.8
+      Till 1.7 version:
       ```
       $ kubeadm init --use-kubernetes-version=v1.7.0 --pod-network-cidr=10.244.0.0/16
+      ```
+
+      For 1.8 version:
+      ```
+      $ kubeadm init --pod-network-cidr=10.244.0.0/16
+      ```
+
+      Next steps:
+      ```
       $ mkdir -p $HOME/.kube
       $ sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
       $ sudo chown $(id -u):$(id -g) $HOME/.kube/config
@@ -26,10 +36,15 @@
 ### Installing genie
 
 We install genie as a Docker Container on every node
+Till Kubernetes 1.7 version: 
 ```
 $ kubectl apply -f https://raw.githubusercontent.com/Huawei-PaaS/CNI-Genie/master/conf/1.5/genie.yaml
 ```
 
+For Kubernetes 1.8 version:
+```
+$ kubectl apply -f https://raw.githubusercontent.com/Huawei-PaaS/CNI-Genie/master/conf/1.8/genie.yaml
+```
 ### Making changes to and build from source
 
 Note that you should install genie first before making changes to the source. This ensures genie conf file is generated successfully.


### PR DESCRIPTION
For making genie work with kubernetes 1.8 version,   ClusterRole, ClusterRoleBinding and ServiceAccount are added in genie yaml

Accordingly, GettingStarted.md updated to guide users based on version they are interested in

Detailed test report added:
[Test-Report.docx](https://github.com/Huawei-PaaS/CNI-Genie/files/1461806/Test-Report.docx)

