### PR TITLE
Add support for macvlan network

### DIFF
--- a/cni-genie_k8s_test.go
+++ b/cni-genie_k8s_test.go
@@ -362,6 +362,50 @@ var _ = Describe("CNIGenie", func() {
 			})
 		})
 	})
+	Describe("Add macvlan networking for Pod", func() {
+		glog.Info("Inside Check for adding macvlan networking")
+		Context("using cni-genie for configuring macvlan CNI", func() {
+			name := fmt.Sprintf("nginx-macvlan-%d", rand.Uint32())
+
+			It("should succeed macvlan networking for pod", func() {
+				annots := make(map[string]string)
+				annots["cni"] = "macvlan"
+				_, err := clientset.Pods(TEST_NAMESPACE).Create(&v1.Pod{
+					ObjectMeta: v1.ObjectMeta{
+						Name:        name,
+						Annotations: annots,
+					},
+					Spec: v1.PodSpec{Containers: []v1.Container{{
+						Name:            fmt.Sprintf("container-%s", name),
+						Image:           "nginx:latest",
+						ImagePullPolicy: "IfNotPresent",
+					}}},
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Waiting for the macvlan pod to have running status")
+				By("Waiting 10 seconds")
+				time.Sleep(time.Duration(10 * time.Second))
+				pod, err := clientset.Pods(TEST_NAMESPACE).Get(name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				glog.Info("pod status =", string(pod.Status.Phase))
+				Expect(string(pod.Status.Phase)).To(Equal("Running"))
+
+				By("Pod was in Running state... Time to delete the macvlan pod now...")
+				err = clientset.Pods(TEST_NAMESPACE).Delete(name, &v1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				By("Waiting 5 seconds")
+				time.Sleep(time.Duration(5 * time.Second))
+				By("Check for macvlan pod deletion")
+				_, err = clientset.Pods(TEST_NAMESPACE).Get(name, metav1.GetOptions{})
+				if err != nil && errors.IsNotFound(err) {
+					//do nothing pod has already been deleted
+				}
+				Expect("Success").To(Equal("Success"))
+			})
+		})
+	})
 })
 var _ = BeforeSuite(func() {
 	var config *rest.Config

--- a/genie/genie-controller.go
+++ b/genie/genie-controller.go
@@ -21,8 +21,8 @@ package genie
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Huawei-PaaS/CNI-Genie/utils"
 	"github.com/Huawei-PaaS/CNI-Genie/plugins"
+	"github.com/Huawei-PaaS/CNI-Genie/utils"
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/ipam"
 	"github.com/containernetworking/cni/pkg/skel"
@@ -424,7 +424,7 @@ func checkPluginBinary(cniName string) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("CNI Genie Error user requested for unsupported plugin type %s. Only supported are (Romana, weave, canal, calico, flannel, bridge)", cniName)
+	return fmt.Errorf("CNI Genie Error user requested for unsupported plugin type %s. Only supported are (Romana, weave, canal, calico, flannel, bridge, macvlan)", cniName)
 }
 
 // placeConfFile creates a conf file in the specified directory path
@@ -455,8 +455,11 @@ func createConfIfBinaryExists(cniName string) ([]byte, error) {
 	case plugins.BridgeNet:
 		pluginObj = plugins.GetBridgeConfig()
 		break
+	case plugins.Macvlan:
+		pluginObj = plugins.GetMacvlanConfig()
+		break
 	default:
-		return nil, fmt.Errorf("CNI Genie Error user requested for unsupported plugin type %s. Only supported are (Romana, weave, canal, calico, flannel, bridge)", cniName)
+		return nil, fmt.Errorf("CNI Genie Error user requested for unsupported plugin type %s. Only supported are (Romana, weave, canal, calico, flannel, bridge, macvlan)", cniName)
 	}
 
 	confFile, confBytes, err := placeConfFile(&pluginObj, cniName)

--- a/plugins/macvlan.go
+++ b/plugins/macvlan.go
@@ -1,0 +1,47 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugins
+
+const (
+	// Macvlan specifies macvlan network
+	Macvlan = "macvlan"
+	// DefaultIpamForMacvlan specifies the default ipam type for macvlan
+	DefaultIpamForMacvlan = "host-local"
+	// DefaultSubnet denotes the default subnet to be used to assign ip from
+	DefaultSubnet = "10.10.0.0/16"
+	// DefaultMasterForMacvlan specifies the default interface for macvlan
+	DefaultMasterForMacvlan = "eth0"
+)
+
+func GetMacvlanConfig() interface{} {
+	macvlanObj := struct {
+		Name   string      `json:"name"`
+		Type   string      `json:"type"`
+		Master string      `json:"master"`
+		Ipam   interface{} `json:"ipam"`
+	}{
+		Name:   "macvlannet",
+		Type:   Macvlan,
+		Master: DefaultMasterForMacvlan,
+		Ipam: struct {
+			Type   string `json:"type"`
+			Subnet string `json:"subnet"`
+		}{
+			Type:   DefaultIpamForMacvlan,
+			Subnet: DefaultSubnet,
+		},
+	}
+
+	return macvlanObj
+}

--- a/sampleyamls/pod-macvlan.yaml
+++ b/sampleyamls/pod-macvlan.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-macvlan
+  labels:
+    app: web
+  annotations:
+    cni: "macvlan"
+spec:
+  containers:
+    - name: key-value-store
+      image: nginx:latest
+      imagePullPolicy: IfNotPresent
+      ports:
+        - containerPort: 6379

--- a/utils/types.go
+++ b/utils/types.go
@@ -56,18 +56,10 @@ type CNIArgs struct {
 
 // NetConf stores the common network config for Calico CNI plugin
 type NetConf struct {
-	CNIVersion string `json:"cniVersion"`
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	IPAM       struct {
-		Name       string
-		Type       string   `json:"type"`
-		Subnet     string   `json:"subnet"`
-		AssignIpv4 *string  `json:"assign_ipv4"`
-		AssignIpv6 *string  `json:"assign_ipv6"`
-		IPv4Pools  []string `json:"ipv4_pools,omitempty"`
-		IPv6Pools  []string `json:"ipv6_pools,omitempty"`
-	} `json:"ipam,omitempty"`
+	CNIVersion     string                 `json:"cniVersion"`
+	Name           string                 `json:"name"`
+	Type           string                 `json:"type"`
+	IPAM           interface{}            `json:"ipam,omitempty"`
 	MTU            int                    `json:"mtu"`
 	Hostname       string                 `json:"hostname"`
 	DatastoreType  string                 `json:"datastore_type"`

--- a/utils/types.go
+++ b/utils/types.go
@@ -85,6 +85,8 @@ type NetConf struct {
 	CalicoSubnet   string                 `json:"calico_subnet"`
 	CanalSubnet    string                 `json:"canal_subnet"`
 	WeaveSubnet    string                 `json:"weave_subnet"`
+	Master         string                 `json:"master"`
+	Mode           string                 `json:"mode"`
 
 	Bridge           string `json:"bridge,omitempty"`
 	IsDefaultGateway bool   `json:"isDefaultGateway,omitempty"`


### PR DESCRIPTION
This PR adds support for macvlan network to CNI Genie.

Test report:
[Test.Report.docx](https://github.com/Huawei-PaaS/CNI-Genie/files/1508708/Test.Report.docx)

