### PR TITLE
Cluster role update for patch operation

### DIFF
--- a/conf/1.8/genie.yaml
+++ b/conf/1.8/genie.yaml
@@ -10,6 +10,7 @@ rules:
       - pods
     verbs:
       - get
+      - patch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
Patch was not working since there was no permission for patch operation in cluster role. So multi ip preference was not getting updated in pod
![image](https://user-images.githubusercontent.com/30930862/34481668-6ec337a2-efd9-11e7-96a9-daa0d015c974.png)


Updated genie.yaml file to add  permission for patch operation

Test report: 
[test-report.docx](https://github.com/Huawei-PaaS/CNI-Genie/files/1597383/test-report.docx)



