### PR TITLE
Add support for conflists

### DIFF
--- a/genie/genie-controller.go
+++ b/genie/genie-controller.go
@@ -118,16 +118,8 @@ func AddPodNetwork(cniArgs utils.CNIArgs, conf utils.NetConf) (types.Result, err
 
 	var newErr error
 	for i, ele := range annots {
-		// in case of multi network or multi-ip-per-pod
-		// we should always reinitalize the conf to
-		// original value that came from StdinData
-		conf, err = ParseCNIConf(cniArgs.StdinData)
-		if err != nil {
-			newErr = err
-		}
-
 		// fetches an IP from corresponding CNS IPAM and returns result object
-		result, err = addNetwork(conf, i, ele, cniArgs)
+		result, err = addNetwork(i, ele, cniArgs)
 		fmt.Fprintf(os.Stderr, "CNI Genie addNetwork err *** %v\n", err)
 		fmt.Fprintf(os.Stderr, "CNI Genie addNetwork result***  %v\n", result)
 		if err != nil {
@@ -175,16 +167,8 @@ func DeletePodNetwork(cniArgs utils.CNIArgs, conf utils.NetConf) error {
 
 	var newErr error
 	for i, ele := range annots {
-		// in case of multi network or multi-ip-per-pod
-		// we should always reinitalize the conf to
-		// original value that came from StdinData
-		conf, err = ParseCNIConf(cniArgs.StdinData)
-		if err != nil {
-			newErr = err
-		}
-
 		// releases an IP from corresponding CNS IPAM and returns error if any exception
-		err = deleteNetwork(conf, i, ele, cniArgs)
+		err = deleteNetwork(i, ele, cniArgs)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "CNI Genie Error deleteNetwork %v", err)
 			newErr = err
@@ -477,7 +461,7 @@ func createConfIfBinaryExists(cniName string) ([]byte, error) {
 }
 
 // addNetwork is a core function that delegates call to pull IP from a Container Networking Solution (CNI Plugin)
-func addNetwork(conf utils.NetConf, intfId int, cniName string, cniArgs utils.CNIArgs) (types.Result, error) {
+func addNetwork(intfId int, cniName string, cniArgs utils.CNIArgs) (types.Result, error) {
 	var result types.Result
 	var stdinData []byte
 	var err error
@@ -538,8 +522,9 @@ func addNetwork(conf utils.NetConf, intfId int, cniName string, cniArgs utils.CN
 }
 
 // deleteNetwork is a core function that delegates call to release IP from a Container Networking Solution (CNI Plugin)
-func deleteNetwork(conf utils.NetConf, intfId int, cniName string, cniArgs utils.CNIArgs) error {
+func deleteNetwork(intfId int, cniName string, cniArgs utils.CNIArgs) error {
 	var stdinData []byte
+	var conf utils.NetConf
 
 	if os.Setenv("CNI_IFNAME", "eth"+strconv.Itoa(intfId)) != nil {
 		fmt.Fprintf(os.Stderr, "CNI_IFNAME Error\n")


### PR DESCRIPTION
This PR adds support for conflist files. The newest flannel cni plugin will work with genie now. I'm using the same approach as kubelet does. Config is now stored in `libcni.NetworkConfigList` it uses `AddNetworkList` and `DeleteNetworkList` functions which by default passes to plugins raw data so it makes #66 obsolete 

This patch depends on https://github.com/Huawei-PaaS/CNI-Genie/pull/72 when it's merged I will rebase this one.

I don't know how, but `plugins_install.sh` worked once for but no it doesn't work and some tests fail. When tested manually everything works.