### PR TITLE
Update travis yaml to support Go version 1.8 onwards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: go
 
 go:
   - 1.x
-  - 1.6
-  - 1.7.x
+  - 1.8.x
   - master
 
 # TODO (Karun): This works only if travis has k8s environment. Hence commenting it for now.


### PR DESCRIPTION
Update tavis yaml to support Go version 1.8 onwards