### PR TITLE
Use annotations passed by env variable

### DIFF
--- a/genie/genie-controller.go
+++ b/genie/genie-controller.go
@@ -315,7 +315,20 @@ func ParsePodAnnotationsForCNI(client *kubernetes.Clientset, k8sArgs utils.K8sAr
 
 	annot, err := getK8sPodAnnotations(client, k8sArgs)
 	if err != nil {
-		return annots, err
+		args := k8sArgs.K8S_ANNOT
+		if len(args) == 0 {
+			fmt.Fprintf(os.Stderr, "CNI Genie no env var and no pod")
+			return annots, err
+		}
+		fmt.Fprintf(os.Stderr, "CNI Genie env  annot val: %s", args)
+		envAnnot := map[string]string{}
+		errEnv := json.Unmarshal([]byte(args), &envAnnot)
+		if errEnv != nil {
+			fmt.Fprintf(os.Stderr, "CNI Genie error getting annotations from pod: `%v` and Error Using annotations from ENV: `%v`\n", err, errEnv)
+			return annots, err
+		}
+		annot = envAnnot
+		fmt.Fprintf(os.Stderr, "CNI Genie error getting annotations from pod: %v. Using annotations from ENV: annot= %v\n", err, annot)
 	}
 	fmt.Fprintf(os.Stderr, "CNI Genie annot= [%s]\n", annot)
 

--- a/utils/types.go
+++ b/utils/types.go
@@ -117,6 +117,7 @@ type K8sArgs struct {
 	K8S_POD_NAME               types.UnmarshallableString
 	K8S_POD_NAMESPACE          types.UnmarshallableString
 	K8S_POD_INFRA_CONTAINER_ID types.UnmarshallableString
+	K8S_ANNOT                  types.UnmarshallableString
 }
 
 // Temporary/alpha structures to support multiple ip addresses within Pod.


### PR DESCRIPTION
Genie currently can work only with kubernetes. It not only requires running k8s but also it needs to be run in a pod context. 

This patch adds alternative path. When Genie can not get annotations from a pod it will check CNI_ARGS for K8S_ANNOT arg and will use data from there.

We need it because we sometimes(in calico case) need to run Genie without assigned pod.
This patch can also simplify writing unit tests because k8s connection is not needed anymore. 