### PR TITLE
Updated calico plugin installation link

### DIFF
--- a/plugins_install.sh
+++ b/plugins_install.sh
@@ -48,7 +48,7 @@ Install_Calico() {
   if [ "$status" == "$desiredState" ]; then
     echo "Calico already running"
   else
-    kubectl apply -f https://docs.projectcalico.org/v2.6/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+    kubectl apply -f https://docs.projectcalico.org/v3.0/getting-started/kubernetes/installation/hosted/kubeadm/1.7/calico.yaml
     echo "Calico is started"
   fi
 }


### PR DESCRIPTION
Updated calico plugin installation link in test execution script

Test Report:
[test-report.docx](https://github.com/Huawei-PaaS/CNI-Genie/files/2169288/test-report.docx)
