### PR TITLE
Default intra-network communication support

### DIFF
--- a/controllers/network-policy-controller/iptables/iptables.go
+++ b/controllers/network-policy-controller/iptables/iptables.go
@@ -29,6 +29,9 @@ const (
 	ForwardChain       = "FORWARD"
 	GeniePolicyPrefix  = "GnPlc-"
 	GenieNetworkPrefix = "GnNtk-"
+	// defaultRuleCountForNetworkChain specifies the number of rules present in a
+	// network chain when no policy chain rules are present in the network chain
+	defaultRuleCountForNetworkChain = 3
 )
 
 type IpTables struct {
@@ -264,7 +267,7 @@ func (i *IpTables) DeleteNetworkChainRule(nwChain string, rules []string) ([]str
 		}
 	}
 
-	if cnt >= len(nwChainRules) - 3 {
+	if cnt >= len(nwChainRules) - defaultRuleCountForNetworkChain {
 		glog.V(4).Infof("Deleing network chain %s", nwChain)
 		err = i.DeleteNetworkChain(nwChain)
 		if err != nil {

--- a/controllers/network-policy-controller/iptables/iptables.go
+++ b/controllers/network-policy-controller/iptables/iptables.go
@@ -114,7 +114,13 @@ func (i *IpTables) AddNetworkChain(ln *utils.LogicalNetwork) (string, error) {
 		return "", err
 	}
 
-	args := []string{"-j", "REJECT"}
+	args := []string{"-s", ln.Spec.SubSubnet, "-d", ln.Spec.SubSubnet, "-j", "ACCEPT"}
+	err = i.AppendUnique(FilterTable, lnChain, args...)
+	if err != nil {
+		return "", err
+	}
+
+	args = []string{"-j", "REJECT"}
 	err = i.AppendUnique(FilterTable, lnChain, args...)
 	if err != nil {
 		return "", err
@@ -258,7 +264,7 @@ func (i *IpTables) DeleteNetworkChainRule(nwChain string, rules []string) ([]str
 		}
 	}
 
-	if cnt >= len(nwChainRules) - 2 {
+	if cnt >= len(nwChainRules) - 3 {
 		glog.V(4).Infof("Deleing network chain %s", nwChain)
 		err = i.DeleteNetworkChain(nwChain)
 		if err != nil {

--- a/controllers/network-policy-controller/iptables/iptables.go
+++ b/controllers/network-policy-controller/iptables/iptables.go
@@ -14,13 +14,13 @@ package iptable
 
 import (
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"github.com/Huawei-PaaS/CNI-Genie/utils"
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/golang/glog"
 	"strconv"
 	"strings"
-	"errors"
 )
 
 const (
@@ -48,8 +48,8 @@ func CreateIptableChainName(prefix, suffix string) string {
 }
 
 func CreatePolicyChainName(name, namespace, args string) string {
-	policyChain := CreateIptableChainName("", name + namespace)[:10]
-	nwPolicyChainName := CreateIptableChainName(GeniePolicyPrefix + policyChain + "-", args)
+	policyChain := CreateIptableChainName("", name+namespace)[:10]
+	nwPolicyChainName := CreateIptableChainName(GeniePolicyPrefix+policyChain+"-", args)
 	return nwPolicyChainName
 }
 
@@ -216,12 +216,12 @@ func (i *IpTables) DeleteNetworkChainRule(nwChain string, rules []string) ([]str
 	policyRules := make(map[string]map[string]int)
 	for pos, rule := range nwChainRules {
 		if strings.Contains(rule, GeniePolicyPrefix) {
-			rule = rule[strings.LastIndex(rule, " ") + 1:]
+			rule = rule[strings.LastIndex(rule, " ")+1:]
 			lastindex := strings.LastIndex(rule, "-")
-			if policyRules[rule[:lastindex + 1]] == nil {
-				policyRules[rule[:lastindex + 1]] = make(map[string]int)
+			if policyRules[rule[:lastindex+1]] == nil {
+				policyRules[rule[:lastindex+1]] = make(map[string]int)
 			}
-			policyRules[rule[:lastindex + 1]][rule[lastindex + 1:]] = pos
+			policyRules[rule[:lastindex+1]][rule[lastindex+1:]] = pos
 		}
 	}
 	glog.V(6).Infof("Policy rules map with policy rule positions: %v", policyRules)
@@ -242,11 +242,11 @@ func (i *IpTables) DeleteNetworkChainRule(nwChain string, rules []string) ([]str
 				glog.V(6).Infof("Deleting rule (%s) from network chain (%s): position: %s", r, nwChain, delPos)
 				err = i.Delete(FilterTable, nwChain, strconv.Itoa(delPos))
 				if err != nil {
-					errmsg = errmsg + fmt.Sprintf("Error deleting rule (%s) from network chain (%s): %v;\t", policy + selector, nwChain, err)
+					errmsg = errmsg + fmt.Sprintf("Error deleting rule (%s) from network chain (%s): %v;\t", policy+selector, nwChain, err)
 				} else {
 					cnt++
 					lastPos = delPos
-					rulesDeleted = append(rulesDeleted, policy + selector)
+					rulesDeleted = append(rulesDeleted, policy+selector)
 				}
 			} else if r == policy {
 				for s, delPos := range policyRules[policy] {
@@ -256,18 +256,18 @@ func (i *IpTables) DeleteNetworkChainRule(nwChain string, rules []string) ([]str
 					glog.V(6).Infof("Deleting rule (%s) from network chain (%s): position: %s", r, nwChain, delPos)
 					err = i.Delete(FilterTable, nwChain, strconv.Itoa(delPos))
 					if err != nil {
-						errmsg = errmsg + fmt.Sprintf("Error deleting rule (%s) from network chain (%s): %v;\t", policy + s, nwChain, err)
+						errmsg = errmsg + fmt.Sprintf("Error deleting rule (%s) from network chain (%s): %v;\t", policy+s, nwChain, err)
 					} else {
 						cnt++
 						lastPos = delPos
-						rulesDeleted = append(rulesDeleted, policy + s)
+						rulesDeleted = append(rulesDeleted, policy+s)
 					}
 				}
 			}
 		}
 	}
 
-	if cnt >= len(nwChainRules) - defaultRuleCountForNetworkChain {
+	if cnt >= len(nwChainRules)-defaultRuleCountForNetworkChain {
 		glog.V(4).Infof("Deleing network chain %s", nwChain)
 		err = i.DeleteNetworkChain(nwChain)
 		if err != nil {

--- a/controllers/network-policy-controller/networkpolicycontroller.go
+++ b/controllers/network-policy-controller/networkpolicycontroller.go
@@ -540,13 +540,13 @@ func (npc *NetworkPolicyController) ListNetworkPolicies(lnwname string, namespac
 	return asSelector, asPeer, nil
 }
 
-func (npc *NetworkPolicyController) insertPeerRule(policyChain, selector, peer string) error {
-	rulespec := []string{"-s", selector, "-d", peer, "-j", "ACCEPT"}
+func (npc *NetworkPolicyController) insertPeerRule(policyChain, selectorSubnet, peerSubnet string) error {
+	rulespec := []string{"-s", selectorSubnet, "-d", peerSubnet, "-j", "ACCEPT"}
 	err := npc.iptable.AppendUnique(iptables.FilterTable, policyChain, rulespec...)
 	if err != nil {
 		return fmt.Errorf("Error adding rule (%v): %v", rulespec, err)
 	}
-	rulespec = []string{"-s", peer, "-d", selector, "-j", "ACCEPT"}
+	rulespec = []string{"-s", peerSubnet, "-d", selectorSubnet, "-j", "ACCEPT"}
 	err = npc.iptable.AppendUnique(iptables.FilterTable, policyChain, rulespec...)
 	if err != nil {
 		return fmt.Errorf("Error adding rule (%v): %v", rulespec, err)


### PR DESCRIPTION
1. Allow communication among pods within a logical network by default
2. Address issue where adding peer network to one policy affects communication among networks defined in other policy.